### PR TITLE
Handle single digit year

### DIFF
--- a/PyQT5_fbs/src/main/python/station_tools/extractor2.py
+++ b/PyQT5_fbs/src/main/python/station_tools/extractor2.py
@@ -178,6 +178,7 @@ class DataExtractor(Month):
                 year = "20" + year
             if len(year) == 1:
                 year = "200" + year
+            #
 
             init_date = np.datetime64("-".join([year, month, day]) + 'T00:00:00.000000')
             self.init_dates.append(init_date)

--- a/PyQT5_fbs/src/main/python/station_tools/extractor2.py
+++ b/PyQT5_fbs/src/main/python/station_tools/extractor2.py
@@ -178,7 +178,6 @@ class DataExtractor(Month):
                 year = "20" + year
             if len(year) == 1:
                 year = "200" + year
-            #
 
             init_date = np.datetime64("-".join([year, month, day]) + 'T00:00:00.000000')
             self.init_dates.append(init_date)

--- a/PyQT5_fbs/src/main/python/station_tools/extractor2.py
+++ b/PyQT5_fbs/src/main/python/station_tools/extractor2.py
@@ -174,8 +174,10 @@ class DataExtractor(Month):
                 day = "0" + day
             if len(month) == 1:
                 month = "0" + month
-            if len(year) < 4:
+            if len(year) == 2:
                 year = "20" + year
+            if len(year) == 1:
+                year = "200" + year
 
             init_date = np.datetime64("-".join([year, month, day]) + 'T00:00:00.000000')
             self.init_dates.append(init_date)


### PR DESCRIPTION
I dont quite remember why I had to do this patch in the first place, but I think it had to do with calls made to extractor2.py from a external program, and if the year parameter was sent with no leading zero, Bad Things (tm) happened.