### PR TITLE
Support external DB env config for packaged QCSoft installs

### DIFF
--- a/PyQT5_fbs/requirements/base.txt
+++ b/PyQT5_fbs/requirements/base.txt
@@ -19,5 +19,5 @@ scipy==1.4.1
 sip==4.19.8
 six==1.11.0
 # DB-enabled station_tools release used by QCSoft.
-uhslc-station-tools[db]==0.0.201
+uhslc-station-tools[db]==0.0.208
 utide==0.2.5

--- a/PyQT5_fbs/src/build/settings/base.json
+++ b/PyQT5_fbs/src/build/settings/base.json
@@ -1,9 +1,9 @@
 {
     "app_name": "UHSLC-QC",
     "main_module": "src/main/python/main.py",
-    "author": "Nemo K.",
+    "author": "Nemo K.; maintained by Samuel W.",
     "public_settings":["app_name","version"],
-    "version": "2.7.0",
+    "version": "2.7.1",
     "hidden_imports": [
         "utide",
         "darkdetect",

--- a/PyQT5_fbs/src/main/python/main.py
+++ b/PyQT5_fbs/src/main/python/main.py
@@ -4,16 +4,37 @@ import csv
 import time
 import traceback
 import tempfile
-
-try:
-    from uhslc_station_tools.db.envfile import load_env_db
-    load_env_db()
-except Exception:
-    pass
-
 import logging
+
 logging.basicConfig(level=logging.INFO)
 logging.getLogger().setLevel(logging.INFO)
+
+try:
+    from uhslc_station_tools.db.envfile import (
+        find_env_db_path,
+        get_env_db_search_paths,
+        has_db_env,
+        load_env_db,
+    )
+
+    _env_db_path = find_env_db_path()
+    _env_db_loaded = load_env_db()
+
+    if _env_db_loaded and _env_db_path:
+        logging.info("DB env file loaded | path=%s", _env_db_path)
+    elif has_db_env():
+        logging.info("DB env values detected in process environment; no .env_db file was loaded.")
+    else:
+        logging.warning(
+            "No DB env file found; DB-backed overlay/write features may be unavailable. "
+            "Searched: %s",
+            "; ".join(get_env_db_search_paths()),
+        )
+except Exception:
+    logging.exception(
+        "Failed to load DB env configuration; DB-backed overlay/write features may be unavailable."
+    )
+
 logging.info("DB read logging mode | TSDB_LOG_SQL=%s", os.getenv("TSDB_LOG_SQL", "spec"))
 logging.info("DB debug logging mode | TSDB_LOG_DEBUG=%s", os.getenv("TSDB_LOG_DEBUG", "0"))
 

--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ Install the requirements using pip based on the OS you are working on:
 
 ```
 # If working on a Mac
-pip install -r requirements/mac.txt
+python -m pip install -r requirements/mac.txt
 
 # Similarly, on Windows:
-pip install -r requirements/windows.txt
+python -m pip install -r requirements/windows.txt
 ```
 
 If you ever decide to add additional dependencies that are platform specific, you would add a dependency into the 
@@ -55,7 +55,7 @@ you need to make changes to the station_tools library and use those changes whil
 have to install it in editable mode. To do so, uninstall the station_tools library if it is already installed and then
 run the following command from the project's root folder (PyQT5_fbs):
 ```
-pip install -e path_to_station_tools_folder
+python -m pip install -e path_to_station_tools_folder
 ```
 You will of course have to replace path_to_station_tools_folder with the actual path to where you checked out the 
 station_tools repo.
@@ -64,49 +64,183 @@ station_tools repo.
 
 This QCSoft branch can use optional DB-backed functionality from `uhslc_station_tools`, including DB overlay reads and save-time DB reconciliation/write hooks.
 
-The standard file-based QC workflow still depends on `uhslc_station_tools`, but DB-backed functionality additionally requires the station-tools `db` extra:
-
-```bash
-pip install "uhslc-station-tools[db]==0.0.201"
-```
+The standard file-based QC workflow still depends on `uhslc_station_tools`, but DB-backed functionality additionally requires the station-tools `db` extra.
 
 For normal QCSoft setup, this is handled through:
 
 ```bash
-pip install -r requirements/mac.txt
+python -m pip install -r requirements/mac.txt
 ```
 
 or:
 
 ```bash
-pip install -r requirements/windows.txt
+python -m pip install -r requirements/windows.txt
+```
+
+or:
+
+```bash
+python -m pip install -r requirements/linux.txt
 ```
 
 depending on your platform.
 
-##### Local DB configuration
+If installing the station-tools dependency directly, use the same version pinned in `PyQT5_fbs/requirements/base.txt`.
 
-DB credentials should not be committed.
+##### DB configuration for installed QCSoft
 
-For local development, copy the example DB environment file:
+DB credentials should not be committed to git and should not be bundled inside the QCSoft installer, DMG, `.app` bundle, source repo, or Python package.
+
+For installed QCSoft use, place the real `.env_db` file in the standard OS config location for the machine.
+
+macOS per-user:
+
+```text
+~/Library/Application Support/UHSLC-QC/.env_db
+```
+
+macOS system-wide:
+
+```text
+/Library/Application Support/UHSLC-QC/.env_db
+```
+
+Windows per-user:
+
+```text
+%APPDATA%\UHSLC-QC\.env_db
+```
+
+Windows system-wide:
+
+```text
+%ProgramData%\UHSLC-QC\.env_db
+```
+
+Linux per-user:
+
+```text
+~/.config/uhslc-qc/.env_db
+```
+
+Linux system-wide:
+
+```text
+/etc/uhslc-qc/.env_db
+```
+
+QCSoft loads DB credentials through `uhslc_station_tools.db.envfile.load_env_db()`. The lookup order is:
+
+1. `TSDB_ENV_FILE`, if explicitly set
+2. Per-user OS config location
+3. System-wide OS config location
+4. Legacy package-adjacent `.env_db` next to `uhslc_station_tools/db/envfile.py`
+
+This allows packaged QCSoft installs to use DB credentials without storing secrets inside the packaged application.
+
+##### Installing `.env_db` on macOS
+
+For a normal per-user Mac install:
+
+```bash
+mkdir -p "$HOME/Library/Application Support/UHSLC-QC"
+cp /path/to/real/.env_db "$HOME/Library/Application Support/UHSLC-QC/.env_db"
+chmod 600 "$HOME/Library/Application Support/UHSLC-QC/.env_db"
+```
+
+For a system-wide Mac install:
+
+```bash
+sudo mkdir -p "/Library/Application Support/UHSLC-QC"
+sudo cp /path/to/real/.env_db "/Library/Application Support/UHSLC-QC/.env_db"
+sudo chmod 600 "/Library/Application Support/UHSLC-QC/.env_db"
+```
+
+After that, launch QCSoft normally from `/Applications`.
+
+##### Installing `.env_db` on Windows
+
+For a normal per-user Windows install, in PowerShell:
+
+```powershell
+New-Item -ItemType Directory -Force "$env:APPDATA\UHSLC-QC"
+Copy-Item "C:\path\to\real\.env_db" "$env:APPDATA\UHSLC-QC\.env_db"
+```
+
+For a system-wide Windows install, in an administrator PowerShell:
+
+```powershell
+New-Item -ItemType Directory -Force "$env:ProgramData\UHSLC-QC"
+Copy-Item "C:\path\to\real\.env_db" "$env:ProgramData\UHSLC-QC\.env_db"
+```
+
+##### Installing `.env_db` on Linux
+
+For a normal per-user Linux install:
+
+```bash
+mkdir -p "$HOME/.config/uhslc-qc"
+cp /path/to/real/.env_db "$HOME/.config/uhslc-qc/.env_db"
+chmod 600 "$HOME/.config/uhslc-qc/.env_db"
+```
+
+For a system-wide Linux install:
+
+```bash
+sudo mkdir -p /etc/uhslc-qc
+sudo cp /path/to/real/.env_db /etc/uhslc-qc/.env_db
+sudo chmod 600 /etc/uhslc-qc/.env_db
+```
+
+##### Local DB configuration for development
+
+For local development, copy the example DB environment file to a private location.
+
+Option 1: use the same OS config location used by installed QCSoft.
+
+macOS:
+
+```bash
+mkdir -p "$HOME/Library/Application Support/UHSLC-QC"
+cp PyQT5_fbs/.env_db.example "$HOME/Library/Application Support/UHSLC-QC/.env_db"
+chmod 600 "$HOME/Library/Application Support/UHSLC-QC/.env_db"
+```
+
+Linux:
+
+```bash
+mkdir -p "$HOME/.config/uhslc-qc"
+cp PyQT5_fbs/.env_db.example "$HOME/.config/uhslc-qc/.env_db"
+chmod 600 "$HOME/.config/uhslc-qc/.env_db"
+```
+
+Windows PowerShell:
+
+```powershell
+New-Item -ItemType Directory -Force "$env:APPDATA\UHSLC-QC"
+Copy-Item "PyQT5_fbs\.env_db.example" "$env:APPDATA\UHSLC-QC\.env_db"
+```
+
+Then edit the copied `.env_db` with your local credentials.
+
+Option 2: use `TSDB_ENV_FILE` as an explicit development override.
+
+macOS/Linux:
 
 ```bash
 cp PyQT5_fbs/.env_db.example PyQT5_fbs/.env_db
-```
-
-Then edit `PyQT5_fbs/.env_db` with your local credentials.
-
-Before running QCSoft locally, point the station-tools DB loader at that file:
-
-```bash
 export TSDB_ENV_FILE="$PWD/PyQT5_fbs/.env_db"
 ```
 
-On Windows PowerShell:
+Windows PowerShell:
 
 ```powershell
+Copy-Item "PyQT5_fbs\.env_db.example" "PyQT5_fbs\.env_db"
 $env:TSDB_ENV_FILE = "$PWD\PyQT5_fbs\.env_db"
 ```
+
+`TSDB_ENV_FILE` is useful for development, testing, CI, and special deployments. Normal installed users should not need to set it.
 
 Supported DB-related environment variables include:
 


### PR DESCRIPTION
## Summary

This PR updates QCSoft to use the new `uhslc_station_tools` DB environment discovery behavior, allowing packaged installs to load database credentials from standard external config locations instead of requiring credentials to be bundled with the app or manually injected through shell environment variables.

## Changes

- Bumps `uhslc-station-tools[db]` to the release that supports cross-platform `.env_db` lookup.
- Adds startup logging around DB environment discovery.
- Documents where users/admins should place the real `.env_db` file on macOS, Windows, and Linux.
- Updates the QCSoft app version to `2.7.1`.
- Updates project metadata to preserve original authorship while noting current maintenance.

## DB config behavior

QCSoft now relies on `uhslc_station_tools.db.envfile.load_env_db()` to search for `.env_db` in this order:

1. `TSDB_ENV_FILE`, if explicitly set
2. Per-user OS config location
3. System-wide OS config location
4. Legacy package-adjacent `.env_db`

This keeps true DB credentials outside the repo, installer, DMG, `.app` bundle, and Python package.

## Testing

- Verified `main.py` compiles successfully.
- Verified QCSoft imports the new station_tools DB env helper functions.
- Confirmed the documented `.env_db` locations align with the new station_tools lookup behavior.